### PR TITLE
Fix missing checkcommand field on Edit_Service

### DIFF
--- a/application/forms/IcingaServiceForm.php
+++ b/application/forms/IcingaServiceForm.php
@@ -514,7 +514,7 @@ class IcingaServiceForm extends DirectorObjectForm
              ->addDisabledElement()
              ->addGroupsElement()
              ->groupMainProperties()
-             ->addCheckCommandElements()
+             ->addCheckCommandElements($this->hasPermission(Permission::ADMIN))
              ->addExtraInfoElements()
              ->setButtons();
 


### PR DESCRIPTION
1. When adding a service, the check command can be entered.
1. The field (CheckCommand) is missing when editing the service.

https://github.com/Icinga/icingaweb2-module-director/issues/2531

https://github.com/Icinga/icingaweb2-module-director/issues/2732